### PR TITLE
[video_player] Removed AudioSession configuration on iOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # :warning: It's a fork of flutter/plugins
 The following changes were necessary to adapt the code to our needs:
-[video_player] [98e0ca1](https://github.com/indaband/flutter_plugins/commit/98e0ca1fa4282a6b6c4277edf5ecb7ed6391f807): Removed AudioSession configuration on iOS.
+
+- [video_player] [98e0ca1](https://github.com/indaband/flutter_plugins/commit/98e0ca1fa4282a6b6c4277edf5ecb7ed6391f807): Removed AudioSession configuration on iOS.
 
 # Flutter plugins
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+# :warning: It's a fork of flutter/plugins
+The following changes were necessary to adapt the code to our needs:
+[video_player] [98e0ca1](https://github.com/indaband/flutter_plugins/commit/98e0ca1fa4282a6b6c4277edf5ecb7ed6391f807): Removed AudioSession configuration on iOS.
+
 # Flutter plugins
 
 [![Build Status](https://api.cirrus-ci.com/github/flutter/plugins.svg)](https://cirrus-ci.com/github/flutter/plugins/main)

--- a/packages/video_player/video_player_avfoundation/ios/Classes/FLTVideoPlayerPlugin.m
+++ b/packages/video_player/video_player_avfoundation/ios/Classes/FLTVideoPlayerPlugin.m
@@ -553,8 +553,10 @@ NS_INLINE UIViewController *rootViewController() {
 }
 
 - (void)initialize:(FlutterError *__autoreleasing *)error {
+  // WE HAVE A CUSTOM AUDIO SESSION CONFIGURATION, SO IT SHOULDN'T BE CONFIGURED HERE.
+  //
   // Allow audio playback when the Ring/Silent switch is set to silent
-  [[AVAudioSession sharedInstance] setCategory:AVAudioSessionCategoryPlayback error:nil];
+  // [[AVAudioSession sharedInstance] setCategory:AVAudioSessionCategoryPlayback error:nil];
 
   [self.playersByTextureId
       enumerateKeysAndObjectsUsingBlock:^(NSNumber *textureId, FLTVideoPlayer *player, BOOL *stop) {
@@ -649,13 +651,15 @@ NS_INLINE UIViewController *rootViewController() {
 
 - (void)setMixWithOthers:(FLTMixWithOthersMessage *)input
                    error:(FlutterError *_Nullable __autoreleasing *)error {
-  if (input.mixWithOthers.boolValue) {
-    [[AVAudioSession sharedInstance] setCategory:AVAudioSessionCategoryPlayback
-                                     withOptions:AVAudioSessionCategoryOptionMixWithOthers
-                                           error:nil];
-  } else {
-    [[AVAudioSession sharedInstance] setCategory:AVAudioSessionCategoryPlayback error:nil];
-  }
+  // WE HAVE A CUSTOM AUDIO SESSION CONFIGURATION, SO IT SHOULDN'T BE CONFIGURED HERE.
+  //
+  //  if (input.mixWithOthers.boolValue) {
+  //    [[AVAudioSession sharedInstance] setCategory:AVAudioSessionCategoryPlayback
+  //                                     withOptions:AVAudioSessionCategoryOptionMixWithOthers
+  //                                           error:nil];
+  //  } else {
+  //    [[AVAudioSession sharedInstance] setCategory:AVAudioSessionCategoryPlayback error:nil];
+  //  }
 }
 
 @end


### PR DESCRIPTION
We have a custom AudioSession configuration, so it shouldn't be set on video_player.
